### PR TITLE
Update versions on scm/scripts/tools

### DIFF
--- a/scm/windowsservercore/Dockerfile
+++ b/scm/windowsservercore/Dockerfile
@@ -14,6 +14,6 @@ RUN Install-SVN -Version $env:SVN_VERSION;
 # Install Git for Windows x64 CLI
 #--------------------------------------------------------------------
 
-ENV GIT_VERSION 2.12.2.2
+ENV GIT_VERSION 2.14.2.2
 
 RUN Install-Git -Version $env:GIT_VERSION;

--- a/scripts/windowsservercore/Dockerfile
+++ b/scripts/windowsservercore/Dockerfile
@@ -30,7 +30,7 @@ RUN Install-Module 7Zip4Powershell \
 # Install VSSetup Module
 #--------------------------------------------------------------------
 
-ENV VS_SETUP_VERSION 1.0.47.27524
+ENV VS_SETUP_VERSION 2.0.1.32208
 
 RUN Install-Module VSSetup \
     -Scope AllUsers \

--- a/tools/windowsservercore/Dockerfile
+++ b/tools/windowsservercore/Dockerfile
@@ -10,7 +10,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 # technically use it for a build-bot.
 #--------------------------------------------------------------------
 
-ENV PERL_VERSION 5.24.1.1
+ENV PERL_VERSION 5.26.0.1
 
 RUN Install-Perl -Version $env:PERL_VERSION -InstallationPath C:\tools\perl;
 
@@ -18,7 +18,7 @@ RUN Install-Perl -Version $env:PERL_VERSION -InstallationPath C:\tools\perl;
 # Install Python
 #--------------------------------------------------------------------
 
-ENV PYTHON_VERSION 2.7.13
+ENV PYTHON_VERSION 2.7.14
 ENV PYTHONIOENCODING utf-8
 ENV PYTHON_PIP_VERSION 9.0.1
 
@@ -40,7 +40,7 @@ RUN Install-Ruby -Version $env:RUBY_VERSION -InstallationPath C:\tools\ruby
 # Install CMake
 #--------------------------------------------------------------------
 
-ENV CMAKE_VERSION 3.8.1
+ENV CMAKE_VERSION 3.9.3
 
 RUN Install-CMake -Version $env:CMAKE_VERSION -InstallationPath C:\tools\cmake;
 
@@ -50,7 +50,7 @@ RUN Install-CMake -Version $env:CMAKE_VERSION -InstallationPath C:\tools\cmake;
 
 RUN Register-SystemPath -Path C:\tools\ninja
 
-ENV NINJA_VERSION 1.7.2
+ENV NINJA_VERSION 1.8.2
 
 RUN Install-Ninja -Version $env:NINJA_VERSION -InstallationPath C:\tools\ninja;
 


### PR DESCRIPTION
Update versions used in the scm, scripts and tools set.

Does not update SVN version without https://github.com/donny-dont/powershell-webkit-dev/pull/1
Does not update ruby to 2.4 due to the oneclick location used not having those versions.